### PR TITLE
PR: Add pypiwin32 dependency only if installing using pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,13 @@ except KeyError:
     library_dirs = []
 
 
-REQUIREMENTS = ['cython', 'pypiwin32']
+REQUIREMENTS = ['cython']
+
+try:
+    import win32file
+except ImportError:
+    REQUIREMENTS += ['pypiwin32']
+
 
 setup(
     name='winpty',


### PR DESCRIPTION
Fixes #15 